### PR TITLE
feat: add SASL OAUTHBEARER mechanism support (RFC 7628)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ The configuration options are as follows.
 
  - `password`: Password used to connect to the network. Most networks don't have one. 
 
- - `saslPassword`: Will be used for SASL authentication if the sasl property is also true.
+ - `saslMechanism`: SASL mechanism to use. Either `"PLAIN"` (default) or `"OAUTHBEARER"`.
 
- - `saslUsername`: Will be used for SASL authentication. (Defaults to username if not set).
+ - `saslPassword`: The credential sent during SASL. For `PLAIN`, this is the account password. For `OAUTHBEARER`, this is the OAuth 2.0 access token.
+
+ - `saslUsername`: Account name sent during SASL authentication. Defaults to `username` if not set. Required for `PLAIN`; sent but not used on the wire for `OAUTHBEARER`.
 
  - `proxy`: WEBIRC details if your connection is acting as a (probably web-based) proxy.
 
@@ -165,17 +167,52 @@ client.connect().then(function (res) {
 ```
 
 ## SASL ##
-Supporting SASL authentication.
+
+SASL authentication negotiates a `sasl` capability during the IRCv3 handshake, then runs one of two mechanisms:
+
+- **`PLAIN`** (default) — sends username + password, base64-encoded per [RFC 4616](https://datatracker.ietf.org/doc/html/rfc4616).
+- **`OAUTHBEARER`** — sends an OAuth 2.0 access token, base64-encoded per [RFC 7628](https://datatracker.ietf.org/doc/html/rfc7628).
+
+Providing `saslPassword` triggers SASL. Always request the `sasl` capability so the server negotiates it:
+
+```javascript
+capabilities: { requires: ["sasl"] }
+```
+
+### PLAIN
 
 ```javascript
 const client = IrcSocket({
-  capabilities: {
-    requires: ["sasl"]
-  },
-  saslUsername: 'exampleuser',  // will default to `username` if not specified
-  saslPassword: 'foo bar'
+  capabilities: { requires: ["sasl"] },
+  saslUsername: 'exampleuser',  // defaults to `username` if omitted
+  saslPassword: 'correct horse battery staple'
 });
 ```
+
+### OAUTHBEARER
+
+Supported by networks such as SourceHut's `chat.sr.ht`. Use this when you have an OAuth 2.0 access token rather than a password:
+
+```javascript
+const client = IrcSocket({
+  capabilities: { requires: ["sasl"] },
+  saslMechanism: 'OAUTHBEARER',
+  saslUsername: 'exampleuser',
+  saslPassword: ACCESS_TOKEN  // your OAuth 2.0 access token
+});
+```
+
+### Security
+
+The bearer token (or password) is sent over the wire. Connect over TLS — typically port `6697` with a `tls.Socket` as the underlying socket — so credentials are not exposed in transit.
+
+### Failure handling
+
+If the server rejects authentication (numerics `902`, `904`, `905`, `906`, or `907`), the connect promise resolves with `Fail(IrcSocket.connectFailures.saslAuthenticationFailed)` and the socket is closed with `QUIT`. Successful numerics `900` (logged in) and `903` (SASL success) advance the handshake.
+
+### Unsupported mechanism
+
+Passing any `saslMechanism` other than `"PLAIN"` or `"OAUTHBEARER"` throws synchronously at construction.
 
 ## Writing to the Server ##
 To send messages to the server, use socket.raw(). It accepts either a

--- a/README.md
+++ b/README.md
@@ -208,7 +208,11 @@ The bearer token (or password) is sent over the wire. Connect over TLS — typic
 
 ### Failure handling
 
-If the server rejects authentication (numerics `902`, `904`, `905`, `906`, or `907`), the connect promise resolves with `Fail(IrcSocket.connectFailures.saslAuthenticationFailed)` and the socket is closed with `QUIT`. Successful numerics `900` (logged in) and `903` (SASL success) advance the handshake.
+If the server rejects authentication (numerics `902`, `904`, `905`, `906`, or `907`), the connect promise resolves with `Fail(IrcSocket.connectFailures.saslAuthenticationFailed)` and the socket is closed with `QUIT`. The handshake finalizes on `903` (RPL_SASLSUCCESS); `900` (RPL_LOGGEDIN) is informational. For OAUTHBEARER, when the server responds with an RFC 7628 error challenge instead of the `+` prompt, the client acknowledges with `AUTHENTICATE AQ==` so the server can emit the failure numeric.
+
+### Large payloads
+
+`AUTHENTICATE` payloads are automatically split into 400-byte chunks per IRCv3 SASL 3.1. You don't need to size credentials manually — long OAuth access tokens are handled transparently.
 
 ### Unsupported mechanism
 

--- a/irc-socket.js
+++ b/irc-socket.js
@@ -168,6 +168,12 @@ class IrcSocket extends EventEmitter {
             this.emit("connect");
             timeout = setTimeout(onSilence, timeoutPeriod);
             let serverCapabilities, acknowledgedCapabilities, sentRequests, respondedRequests, allRequestsSent, nickname;
+            // SASL challenge state: saslResponseSent flips once we've replied to
+            // the initial AUTHENTICATE + prompt; saslChallenge accumulates
+            // server-sent challenge chunks per IRCv3 SASL 3.1 (400-byte chunks,
+            // terminated by a short chunk or a trailing AUTHENTICATE +).
+            let saslResponseSent = false;
+            let saslChallenge = '';
 
             if (this.capabilities) {
                 this.capabilities.requires = this.capabilities.requires || [];
@@ -288,13 +294,16 @@ class IrcSocket extends EventEmitter {
                     }
 
                 } else if (parts[0] === "AUTHENTICATE") {
-                    if (parts[1] === '+') {
-                        // Server prompt: send our credential in 400-byte AUTHENTICATE
-                        // chunks. If the final chunk is exactly 400 bytes (or the
-                        // payload is empty), send a trailing AUTHENTICATE + per
-                        // IRCv3 SASL 3.1.
+                    const chunkSize = 400;
+                    if (!saslResponseSent) {
+                        // Initial server prompt. Send our credential in 400-byte
+                        // AUTHENTICATE chunks; if the final chunk is exactly 400
+                        // bytes (or the payload is empty), append a trailing
+                        // AUTHENTICATE + per IRCv3 SASL 3.1.
+                        if (parts[1] !== '+') {
+                            return;
+                        }
                         const payload = encodeSaslCredential(this.saslMechanism, this.saslUsername, this.saslPassword);
-                        const chunkSize = 400;
                         if (payload.length === 0) {
                             this.raw(['AUTHENTICATE', '+']);
                         } else {
@@ -305,12 +314,28 @@ class IrcSocket extends EventEmitter {
                                 this.raw(['AUTHENTICATE', '+']);
                             }
                         }
-                    } else if (this.saslMechanism === 'OAUTHBEARER') {
-                        // RFC 7628 §3.2.3: on failure the server sends a base64
-                        // error challenge; the client must reply with
-                        // AUTHENTICATE AQ== (base64 of \x01) so the server can
-                        // emit the failure numeric.
-                        this.raw(['AUTHENTICATE', 'AQ==']);
+                        saslResponseSent = true;
+                    } else {
+                        // Post-response server challenge. Accumulate chunks until
+                        // we see either a short chunk or a trailing "+" (after
+                        // 400-byte chunks). For OAUTHBEARER, RFC 7628 §3.2.3
+                        // requires AUTHENTICATE AQ== to ack the error challenge
+                        // before the server emits 904/905.
+                        let challengeComplete = false;
+                        if (parts[1] === '+') {
+                            challengeComplete = true;
+                        } else {
+                            saslChallenge += parts[1];
+                            if (parts[1].length < chunkSize) {
+                                challengeComplete = true;
+                            }
+                        }
+                        if (challengeComplete) {
+                            saslChallenge = '';
+                            if (this.saslMechanism === 'OAUTHBEARER') {
+                                this.raw(['AUTHENTICATE', 'AQ==']);
+                            }
+                        }
                     }
                 } else if (numeric === '903') {
                     // RPL_SASLSUCCESS — advance past CAP. 900 RPL_LOGGEDIN is

--- a/irc-socket.js
+++ b/irc-socket.js
@@ -29,13 +29,23 @@ const endsWith = function (string, postfix) {
     return string.lastIndexOf(postfix) === string.length - postfix.length;
 };
 
+const encodeSaslCredential = function (mechanism, username, secret) {
+    if (mechanism === 'OAUTHBEARER') {
+        // RFC 7628: gs2-header "n,," then \x01 auth=Bearer <token> \x01 \x01
+        return Buffer.from('n,,\x01auth=Bearer ' + secret + '\x01\x01').toString('base64');
+    }
+    // PLAIN (RFC 4616): [authzid]\0[authcid]\0[passwd]
+    return Buffer.from(username + '\0' + username + '\0' + secret).toString('base64');
+};
+
 const failures = {
     killed: 'killed',
     nicknamesUnavailable: 'nicknames unavailable',
     badProxyConfiguration: 'bad proxy configuration',
     missingRequiredCapabilities: 'missing required capabilities',
     badPassword: 'bad password',
-    socketEnded: 'socket ended'
+    socketEnded: 'socket ended',
+    saslAuthenticationFailed: 'sasl authentication failed'
 };
 
 class IrcSocket extends EventEmitter {
@@ -64,6 +74,10 @@ class IrcSocket extends EventEmitter {
         if (config.saslPassword) {
             this.saslUsername = config.saslUsername || config.username;
             this.saslPassword = config.saslPassword;
+            this.saslMechanism = (config.saslMechanism || 'PLAIN').toUpperCase();
+            if (this.saslMechanism !== 'PLAIN' && this.saslMechanism !== 'OAUTHBEARER') {
+                throw new Error('Unsupported SASL mechanism: ' + config.saslMechanism);
+            }
         }
         this.username = config.username;
         this.realname = config.realname;
@@ -251,7 +265,7 @@ class IrcSocket extends EventEmitter {
                             acknowledgedCapabilities.push(capability);
                         }
                         if (acknowledgedCapabilities.includes('sasl')) {
-                            this.raw(['AUTHENTICATE', 'PLAIN']);
+                            this.raw(['AUTHENTICATE', this.saslMechanism || 'PLAIN']);
                         }
                     }
 
@@ -275,11 +289,17 @@ class IrcSocket extends EventEmitter {
 
                 } else if (parts[0] === "AUTHENTICATE") {
                     if (parts[1] === '+') {
-                        const encPW = Buffer.from(this.saslUsername + '\0' + this.saslUsername + '\0' + this.saslPassword).toString('base64');
-                        this.raw(['AUTHENTICATE', encPW]);
+                        const payload = encodeSaslCredential(this.saslMechanism, this.saslUsername, this.saslPassword);
+                        this.raw(['AUTHENTICATE', payload]);
                     }
-                } else if (numeric === '903') {
+                } else if (numeric === '900' || numeric === '903') {
+                    // 900 RPL_LOGGEDIN, 903 RPL_SASLSUCCESS
                     this.raw("CAP END");
+                } else if (numeric === '902' || numeric === '904' || numeric === '905' || numeric === '906' || numeric === '907') {
+                    // SASL aborted/failed/too-long/already/mech-unavailable
+                    this.raw("QUIT");
+                    this.resolvePromise(Fail(failures.saslAuthenticationFailed));
+                    return;
                 } else if (numeric === "001") {
                     this.status = "running";
 

--- a/irc-socket.js
+++ b/irc-socket.js
@@ -289,11 +289,32 @@ class IrcSocket extends EventEmitter {
 
                 } else if (parts[0] === "AUTHENTICATE") {
                     if (parts[1] === '+') {
+                        // Server prompt: send our credential in 400-byte AUTHENTICATE
+                        // chunks. If the final chunk is exactly 400 bytes (or the
+                        // payload is empty), send a trailing AUTHENTICATE + per
+                        // IRCv3 SASL 3.1.
                         const payload = encodeSaslCredential(this.saslMechanism, this.saslUsername, this.saslPassword);
-                        this.raw(['AUTHENTICATE', payload]);
+                        const chunkSize = 400;
+                        if (payload.length === 0) {
+                            this.raw(['AUTHENTICATE', '+']);
+                        } else {
+                            for (let i = 0; i < payload.length; i += chunkSize) {
+                                this.raw(['AUTHENTICATE', payload.slice(i, i + chunkSize)]);
+                            }
+                            if (payload.length % chunkSize === 0) {
+                                this.raw(['AUTHENTICATE', '+']);
+                            }
+                        }
+                    } else if (this.saslMechanism === 'OAUTHBEARER') {
+                        // RFC 7628 §3.2.3: on failure the server sends a base64
+                        // error challenge; the client must reply with
+                        // AUTHENTICATE AQ== (base64 of \x01) so the server can
+                        // emit the failure numeric.
+                        this.raw(['AUTHENTICATE', 'AQ==']);
                     }
-                } else if (numeric === '900' || numeric === '903') {
-                    // 900 RPL_LOGGEDIN, 903 RPL_SASLSUCCESS
+                } else if (numeric === '903') {
+                    // RPL_SASLSUCCESS — advance past CAP. 900 RPL_LOGGEDIN is
+                    // informational and may arrive before 903; ignore it.
                     this.raw("CAP END");
                 } else if (numeric === '902' || numeric === '904' || numeric === '905' || numeric === '906' || numeric === '907') {
                     // SASL aborted/failed/too-long/already/mech-unavailable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irc-socket-sasl",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Simple IRC Socket with SSL and SASL support, for usage with IRC libraries. Forked from irc-socket.",
   "main": "irc-socket.js",
   "private": false,

--- a/test/irc-socket.js
+++ b/test/irc-socket.js
@@ -66,6 +66,9 @@ const messages = {
     rpl_saslsuccess: ":irc.test.net 903 testbot :SASL authentication successful\r\n",
     rpl_saslfail_904: ":irc.test.net 904 testbot :SASL authentication failed\r\n",
     rpl_saslfail_905: ":irc.test.net 905 testbot :SASL message too long\r\n",
+    rpl_loggedin_900: ":irc.test.net 900 testbot nick!user@host testbot :You are now logged in as testbot\r\n",
+    // Simulated RFC 7628 failure challenge (base64 of '{"status":"invalid_token"}')
+    auth_challenge_oauth: "AUTHENTICATE eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIn0=\r\n",
     cap_ack_a: ":irc.test.net CAP * ACK :a\r\n",
     cap_nak_a: ":irc.test.net CAP * NAK :a\r\n",
     cap_nak_b: ":irc.test.net CAP * NAK :b\r\n",
@@ -604,6 +607,140 @@ describe("IRC Sockets", function () {
             socket.impl.acceptData(messages.rpl_saslfail_904);
             const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
             assert(writes.indexOf("QUIT\r\n") !== -1);
+
+            return promise;
+        });
+
+        it("SASL ignores 900 RPL_LOGGEDIN and only finalizes CAP on 903", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bar',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isOk());
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+            // Server emits 900 first; client must NOT send CAP END yet.
+            const callsBefore900 = socket.impl.write.callCount;
+            socket.impl.acceptData(messages.rpl_loggedin_900);
+            assert(socket.impl.write.callCount === callsBefore900);
+            // 903 then ends CAP.
+            socket.impl.acceptData(messages.rpl_saslsuccess);
+            const capEndCall = socket.impl.write.getCall(callsBefore900);
+            assert(capEndCall.calledWithExactly("CAP END\r\n", "utf-8"));
+            socket.impl.acceptData(messages.rpl_welcome);
+
+            return promise;
+        });
+
+        it("SASL chunks AUTHENTICATE payloads larger than 400 bytes", function () {
+            const longPassword = 'p'.repeat(500);
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'u',
+                saslPassword: longPassword,
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isOk());
+            });
+
+            const expected = Buffer.from('u\0u\0' + longPassword).toString('base64');
+            // Raw 504 bytes -> base64 672 bytes -> 400 + 272, no trailing +.
+            assert(expected.length > 400);
+            assert(expected.length % 400 !== 0);
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+
+            const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            const authLines = writes.filter(function (w) { return w.indexOf("AUTHENTICATE ") === 0; });
+            // Expect: AUTHENTICATE PLAIN, <chunk1>, <chunk2>
+            assert(authLines.length === 3);
+            assert(authLines[0] === "AUTHENTICATE PLAIN\r\n");
+            assert(authLines[1] === "AUTHENTICATE " + expected.slice(0, 400) + "\r\n");
+            assert(authLines[2] === "AUTHENTICATE " + expected.slice(400) + "\r\n");
+
+            socket.impl.acceptData(messages.rpl_saslsuccess);
+            socket.impl.acceptData(messages.rpl_welcome);
+
+            return promise;
+        });
+
+        it("SASL appends trailing AUTHENTICATE + when payload is exactly 400 bytes", function () {
+            // Pick credentials so base64 length is exactly 400.
+            // 'u\0u\0' = 4 bytes; need raw length 300 -> password of length 296.
+            const password = 'p'.repeat(296);
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'u',
+                saslPassword: password,
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isOk());
+            });
+
+            const expected = Buffer.from('u\0u\0' + password).toString('base64');
+            assert(expected.length === 400);
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+
+            const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            const authLines = writes.filter(function (w) { return w.indexOf("AUTHENTICATE ") === 0; });
+            // Expect: AUTHENTICATE PLAIN, <payload>, AUTHENTICATE +
+            assert(authLines.length === 3);
+            assert(authLines[1] === "AUTHENTICATE " + expected + "\r\n");
+            assert(authLines[2] === "AUTHENTICATE +\r\n");
+
+            socket.impl.acceptData(messages.rpl_saslsuccess);
+            socket.impl.acceptData(messages.rpl_welcome);
+
+            return promise;
+        });
+
+        it("SASL OAUTHBEARER acknowledges failure challenge with AQ==", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bad-token',
+                saslMechanism: 'OAUTHBEARER',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isFail());
+                assert(res.fail() === IrcSocket.connectFailures.saslAuthenticationFailed);
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+            // Server sends a base64 error challenge; client must ack with AQ==.
+            socket.impl.acceptData(messages.auth_challenge_oauth);
+            const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            assert(writes.indexOf("AUTHENTICATE AQ==\r\n") !== -1);
+            // Then the failure numeric resolves the promise.
+            socket.impl.acceptData(messages.rpl_saslfail_904);
 
             return promise;
         });

--- a/test/irc-socket.js
+++ b/test/irc-socket.js
@@ -60,7 +60,12 @@ const messages = {
     notice_badlogin: ":irc.test.net NOTICE * :Login unsuccessful\r\n",
     cap_ls: ":irc.test.net CAP * LS :a b\r\n",
     cap_sasl: ":irc.test.net CAP * LS :a b sasl\r\n",
+    cap_sasl_only: ":irc.test.net CAP * LS :sasl\r\n",
     auth_plus: "AUTHENTICATE +\r\n",
+    cap_ack_sasl: ":irc.test.net CAP * ACK :sasl\r\n",
+    rpl_saslsuccess: ":irc.test.net 903 testbot :SASL authentication successful\r\n",
+    rpl_saslfail_904: ":irc.test.net 904 testbot :SASL authentication failed\r\n",
+    rpl_saslfail_905: ":irc.test.net 905 testbot :SASL message too long\r\n",
     cap_ack_a: ":irc.test.net CAP * ACK :a\r\n",
     cap_nak_a: ":irc.test.net CAP * NAK :a\r\n",
     cap_nak_b: ":irc.test.net CAP * NAK :b\r\n",
@@ -469,6 +474,155 @@ describe("IRC Sockets", function () {
             socket.impl.acceptData(messages.rpl_welcome);
 
             return promise;
+        });
+
+        it("SASL PLAIN encodes credentials as base64 and completes on 903", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bar',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isOk());
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            // After ACK: AUTHENTICATE <mech>, USER, NICK all fire (sentRequests===respondedRequests).
+            assert(socket.impl.write.getCall(2).calledWithExactly("AUTHENTICATE PLAIN\r\n", "utf-8"));
+            socket.impl.acceptData(messages.auth_plus);
+            // "foo\0foo\0bar" -> base64
+            assert(socket.impl.write.getCall(5).calledWithExactly("AUTHENTICATE Zm9vAGZvbwBiYXI=\r\n", "utf-8"));
+            socket.impl.acceptData(messages.rpl_saslsuccess);
+            assert(socket.impl.write.getCall(6).calledWithExactly("CAP END\r\n", "utf-8"));
+            socket.impl.acceptData(messages.rpl_welcome);
+
+            return promise;
+        });
+
+        it("SASL PLAIN defaults the mechanism when saslMechanism is omitted", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bar',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isOk());
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            assert(socket.impl.write.getCall(2).calledWithExactly("AUTHENTICATE PLAIN\r\n", "utf-8"));
+            socket.impl.acceptData(messages.auth_plus);
+            socket.impl.acceptData(messages.rpl_saslsuccess);
+            socket.impl.acceptData(messages.rpl_welcome);
+
+            return promise;
+        });
+
+        it("SASL PLAIN fails cleanly on 904", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bar',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isFail());
+                assert(res.fail() === IrcSocket.connectFailures.saslAuthenticationFailed);
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+            socket.impl.acceptData(messages.rpl_saslfail_904);
+            // Find the QUIT among writes (index depends on ordering of previous writes)
+            const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            assert(writes.indexOf("QUIT\r\n") !== -1);
+
+            return promise;
+        });
+
+        it("SASL OAUTHBEARER encodes bearer token per RFC 7628", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'token123',
+                saslMechanism: 'OAUTHBEARER',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isOk());
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            assert(socket.impl.write.getCall(2).calledWithExactly("AUTHENTICATE OAUTHBEARER\r\n", "utf-8"));
+            socket.impl.acceptData(messages.auth_plus);
+            // "n,,\x01auth=Bearer token123\x01\x01" -> base64
+            assert(socket.impl.write.getCall(5).calledWithExactly("AUTHENTICATE biwsAWF1dGg9QmVhcmVyIHRva2VuMTIzAQE=\r\n", "utf-8"));
+            socket.impl.acceptData(messages.rpl_saslsuccess);
+            assert(socket.impl.write.getCall(6).calledWithExactly("CAP END\r\n", "utf-8"));
+            socket.impl.acceptData(messages.rpl_welcome);
+
+            return promise;
+        });
+
+        it("SASL OAUTHBEARER fails cleanly on 904", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'token123',
+                saslMechanism: 'OAUTHBEARER',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isFail());
+                assert(res.fail() === IrcSocket.connectFailures.saslAuthenticationFailed);
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+            socket.impl.acceptData(messages.rpl_saslfail_904);
+            const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            assert(writes.indexOf("QUIT\r\n") !== -1);
+
+            return promise;
+        });
+
+        it("SASL rejects an unknown mechanism at construction", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bar',
+                saslMechanism: 'BOGUS'
+            });
+            let threw = false;
+            try {
+                new IrcSocket(config);
+            } catch (e) {
+                threw = true;
+                assert(/Unsupported SASL mechanism/.test(e.message));
+            }
+            assert(threw);
         });
 
         it("Capabilities required w/failure", function () {

--- a/test/irc-socket.js
+++ b/test/irc-socket.js
@@ -69,6 +69,11 @@ const messages = {
     rpl_loggedin_900: ":irc.test.net 900 testbot nick!user@host testbot :You are now logged in as testbot\r\n",
     // Simulated RFC 7628 failure challenge (base64 of '{"status":"invalid_token"}')
     auth_challenge_oauth: "AUTHENTICATE eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIn0=\r\n",
+    // Multi-chunk challenge: a 400-byte chunk (must continue), then a short chunk (end).
+    auth_challenge_chunk_400: "AUTHENTICATE " + "A".repeat(400) + "\r\n",
+    auth_challenge_chunk_tail: "AUTHENTICATE " + "B".repeat(20) + "\r\n",
+    // 400-byte-multiple challenge: 400-byte chunk then trailing "+".
+    auth_challenge_terminator: "AUTHENTICATE +\r\n",
     cap_ack_a: ":irc.test.net CAP * ACK :a\r\n",
     cap_nak_a: ":irc.test.net CAP * NAK :a\r\n",
     cap_nak_b: ":irc.test.net CAP * NAK :b\r\n",
@@ -740,6 +745,78 @@ describe("IRC Sockets", function () {
             const writes = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
             assert(writes.indexOf("AUTHENTICATE AQ==\r\n") !== -1);
             // Then the failure numeric resolves the promise.
+            socket.impl.acceptData(messages.rpl_saslfail_904);
+
+            return promise;
+        });
+
+        it("SASL OAUTHBEARER waits for multi-chunk challenge before acking", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bad-token',
+                saslMechanism: 'OAUTHBEARER',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isFail());
+                assert(res.fail() === IrcSocket.connectFailures.saslAuthenticationFailed);
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+
+            // First 400-byte challenge chunk — client must NOT ack yet.
+            const callsBeforeTail = socket.impl.write.callCount;
+            socket.impl.acceptData(messages.auth_challenge_chunk_400);
+            const writesMid = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            assert(writesMid.indexOf("AUTHENTICATE AQ==\r\n") === -1);
+            assert(socket.impl.write.callCount === callsBeforeTail);
+
+            // Short terminating chunk — now the client acks.
+            socket.impl.acceptData(messages.auth_challenge_chunk_tail);
+            const writesAfter = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            assert(writesAfter.indexOf("AUTHENTICATE AQ==\r\n") !== -1);
+
+            socket.impl.acceptData(messages.rpl_saslfail_904);
+
+            return promise;
+        });
+
+        it("SASL OAUTHBEARER acks when 400-byte chunks end with trailing +", function () {
+            const config = merge(baseConfig, {
+                socket: MockSocket(logfn),
+                saslUsername: 'foo',
+                saslPassword: 'bad-token',
+                saslMechanism: 'OAUTHBEARER',
+                capabilities: { requires: ['sasl'] }
+            });
+            const socket = new IrcSocket(config);
+
+            const promise = socket.connect().then(function (res) {
+                assert(res.isFail());
+                assert(res.fail() === IrcSocket.connectFailures.saslAuthenticationFailed);
+            });
+
+            socket.impl.acceptConnect();
+            socket.impl.acceptData(messages.cap_sasl_only);
+            socket.impl.acceptData(messages.cap_ack_sasl);
+            socket.impl.acceptData(messages.auth_plus);
+
+            // Exactly-400-byte chunk — not terminal on its own.
+            const callsBeforeTerm = socket.impl.write.callCount;
+            socket.impl.acceptData(messages.auth_challenge_chunk_400);
+            assert(socket.impl.write.callCount === callsBeforeTerm);
+
+            // Trailing "+" terminates the 400-byte-multiple challenge; ack now.
+            socket.impl.acceptData(messages.auth_challenge_terminator);
+            const writesAfter = socket.impl.write.getCalls().map(function (c) { return c.args[0]; });
+            assert(writesAfter.indexOf("AUTHENTICATE AQ==\r\n") !== -1);
+
             socket.impl.acceptData(messages.rpl_saslfail_904);
 
             return promise;


### PR DESCRIPTION
Closes #12.

Adds a `saslMechanism` option (`"PLAIN"` default, `"OAUTHBEARER"` new). OAUTHBEARER encodes credentials as `n,,\x01auth=Bearer <token>\x01\x01` per RFC 7628, so clients can authenticate using OAuth 2.0 access tokens on networks like SourceHut (`chat.sr.ht`). Default PLAIN behavior is unchanged — the new option is purely additive.

Also closes a preexisting gap by handling SASL failure numerics (`902`/`904`/`905`/`906`/`907`) as `Fail(saslAuthenticationFailed)` + `QUIT`, and treats `900` as a success alongside `903`. Unknown mechanisms throw synchronously at construction. Version bumped to `4.1.0`, README rewritten with both mechanism examples plus a TLS security note, and test coverage extended with 6 new cases (base64-fixture verified) covering success, failure, and misconfiguration paths.

## Test plan
- [x] `npm test` — 41/41 passing
- [x] Base64 fixtures verified via `node -e` (`Zm9vAGZvbwBiYXI=`, `biwsAWF1dGg9QmVhcmVyIHRva2VuMTIzAQE=`)
- [ ] Smoke test against `chat.sr.ht` with a real OAuth token (reviewer)