### PR TITLE
ci: run tests on push and pull request via GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
## Summary
Adds `.github/workflows/test.yml` so the existing Mocha suite runs automatically on pushes to `master` and on all pull requests, across Node 18/20/22. Previously there was no CI, so regressions could land unnoticed.

## Test plan
- [x] GitHub Actions "Tests" check appears on this PR and passes on all three Node versions
- [x] Verified locally with `npm install && npm test` (47 passing)