### PR TITLE
Replace deep-eql with node:assert.deepStrictEqual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@silverbucket/mock-net-socket": "^2.0.0",
         "better-assert": "^1.0.2",
-        "deep-eql": "^4.1.4",
         "mocha": "^11.0.0",
         "sinon": "^21.0.0"
       }
@@ -422,19 +421,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/diff": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@silverbucket/mock-net-socket": "^2.0.0",
     "better-assert": "^1.0.2",
-    "deep-eql": "^4.1.4",
     "mocha": "^11.0.0",
     "sinon": "^21.0.0"
   },

--- a/test/irc-socket.js
+++ b/test/irc-socket.js
@@ -1,6 +1,6 @@
 const sinon = require("sinon");
 const assert = require("better-assert");
-const equal = require("deep-eql");
+const { deepStrictEqual } = require("node:assert");
 const uinspect = require("util").inspect;
 const format = require("util").format;
 
@@ -437,7 +437,7 @@ describe("IRC Sockets", function () {
             const promise = socket.connect()
             .then(function (res) {
                 assert(res.isOk());
-                assert(equal(res.ok().capabilities, ["a"]));
+                deepStrictEqual(res.ok().capabilities, ["a"]);
             });
 
             socket.impl.acceptConnect();
@@ -467,7 +467,7 @@ describe("IRC Sockets", function () {
             const promise = socket.connect()
               .then(function (res) {
                   assert(res.isOk());
-                  assert(equal(res.ok().capabilities, ["a", "sasl"]));
+                  deepStrictEqual(res.ok().capabilities, ["a", "sasl"]);
               });
 
             socket.impl.acceptConnect();
@@ -881,7 +881,7 @@ describe("IRC Sockets", function () {
             const promise = socket.connect()
             .then(function (res) {
                 assert(res.isOk());
-                assert(equal(res.ok().capabilities, ["a"]));
+                deepStrictEqual(res.ok().capabilities, ["a"]);
             });
 
             socket.impl.acceptConnect();
@@ -909,7 +909,7 @@ describe("IRC Sockets", function () {
             const promise = socket.connect()
             .then(function (res) {
                 assert(res.isOk());
-                assert(equal(res.ok().capabilities, []));
+                deepStrictEqual(res.ok().capabilities, []);
             });
 
             socket.impl.acceptConnect();
@@ -937,7 +937,7 @@ describe("IRC Sockets", function () {
             const promise = socket.connect()
             .then(function (res) {
                 assert(res.isOk());
-                assert(equal(res.ok().capabilities, ["a"]));
+                deepStrictEqual(res.ok().capabilities, ["a"]);
             });
 
             socket.impl.acceptConnect();
@@ -989,10 +989,10 @@ describe("IRC Sockets", function () {
             socket.connect();
             socket.impl.acceptConnect();
 
-            assert(equal(socket.impl.connect.getCall(0).args, [{
+            deepStrictEqual(socket.impl.connect.getCall(0).args, [{
                 port: 6667,
                 host: "irc.test.net"
-            }]));
+            }]);
         });
 
         it("Failure by .end() before connect event fired", function () {


### PR DESCRIPTION
## Summary

- `deep-eql` v5 is pure ESM, so `const equal = require("deep-eql")` no longer returns a callable function from CommonJS, causing `TypeError: equal is not a function` in the test suite (this is what blocked Renovate PR #6).
- Replaces the 6 `assert(equal(a, b))` call sites in `test/irc-socket.js` with Node's built-in `assert.deepStrictEqual(a, b)` and removes the `deep-eql` devDependency entirely.
- Works uniformly on Node 18/20/22 and produces better error messages on mismatch.

## Test plan

- [x] `npm test` passes locally (47/47)
- [ ] GitHub Actions green on Node 18.x / 20.x / 22.x
- [ ] Close Renovate PR #6 as obsolete once this merges