### PR TITLE
Fix connectOptions dropped to tls.connect via Object.create

### DIFF
--- a/irc-socket.js
+++ b/irc-socket.js
@@ -84,7 +84,7 @@ class IrcSocket extends EventEmitter {
         this.nicknames = config.nicknames.slice();
         this.timeout = config.timeout || 5 * 60 * 1000;
 
-        this.connectOptions = typeof config.connectOptions === "object" ? Object.create(config.connectOptions) : {};
+        this.connectOptions = typeof config.connectOptions === "object" && config.connectOptions !== null ? { ...config.connectOptions } : {};
         this.connectOptions.port = config.port || 6667;
         this.connectOptions.host = config.server;
 

--- a/test/irc-socket.js
+++ b/test/irc-socket.js
@@ -152,6 +152,53 @@ describe("IRC Sockets", function () {
         });
     });
 
+    describe("connectOptions", function () {
+        // Regression test for silverbucket/irc-socket-sasl#24.
+        // Caller-supplied connectOptions (e.g. TLS options such as
+        // rejectUnauthorized, ca, key, cert) must be passed to the
+        // underlying impl.connect() as own enumerable properties.
+        // tls.connect() internally spreads (`...options`), which only
+        // copies own enumerable properties, so options living on the
+        // prototype chain (as with Object.create) are silently dropped.
+
+        it("passes caller connectOptions as own enumerable properties", function () {
+            const config = merge(baseConfig, {
+                connectOptions: {
+                    rejectUnauthorized: false,
+                    ca: Buffer.from("dummy-cert"),
+                    servername: "irc.test.net"
+                }
+            });
+            const socket = new IrcSocket(config, MockSocket(logfn));
+            socket.connect();
+
+            const passed = socket.impl.connect.getCall(0).args[0];
+
+            // Own enumerable check == what tls.connect's spread sees.
+            const keys = Object.keys(passed);
+            assert(keys.indexOf("rejectUnauthorized") !== -1);
+            assert(keys.indexOf("ca") !== -1);
+            assert(keys.indexOf("servername") !== -1);
+
+            // Values (and non-JSON-serializable types like Buffer) survive intact.
+            const spread = Object.assign({}, passed);
+            assert(spread.rejectUnauthorized === false);
+            assert(Buffer.isBuffer(spread.ca));
+            assert(spread.servername === "irc.test.net");
+        });
+
+        it("does not mutate the caller's connectOptions object", function () {
+            const connectOptions = { rejectUnauthorized: false };
+            const config = merge(baseConfig, { connectOptions });
+            const socket = new IrcSocket(config, MockSocket(logfn));
+            socket.connect();
+
+            // port/host are set on our copy, not on the caller's object.
+            assert(!Object.prototype.hasOwnProperty.call(connectOptions, "port"));
+            assert(!Object.prototype.hasOwnProperty.call(connectOptions, "host"));
+        });
+    });
+
     describe("Startup Procedure", function () {
         it("Minimal config w/success", function () {
             const socket = new IrcSocket(baseConfig, MockSocket(logfn));


### PR DESCRIPTION
## Summary

Fixes #24.

`IrcSocket` built its connect options with `Object.create(config.connectOptions)`, which placed all caller-supplied options on the **prototype** of the new object rather than as own properties. At connect time this object is handed to `impl.connect(...)`; when `impl` is Node's `tls` module, `tls.connect()` internally spreads `...options`, copying only **own enumerable** properties. As a result, TLS options such as `rejectUnauthorized`, `ca`, `key`, and `cert` were silently dropped and Node's defaults were used instead.

## Fix

Replace `Object.create` with a shallow spread copy (`{ ...config.connectOptions }`) so caller options become own enumerable properties while the caller's original object stays immutable.

A shallow copy is used deliberately — the repo's `copyJsonMaybe` helper (`JSON.parse(JSON.stringify(...))`) would corrupt `Buffer` options (`ca`/`key`/`cert`) and drop function options like `checkServerIdentity`. A `!== null` guard is added since `typeof null === "object"`.

## Tests

Adds a `connectOptions` regression suite:
- caller options (including a `Buffer` `ca`) reach `impl.connect()` as own enumerable properties and survive a spread — mirroring exactly what `tls.connect()` does
- the caller's `connectOptions` object is not mutated

Verified the first test **fails** on the pre-fix `Object.create` code and passes after the fix. Full suite: **51 passing**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of connection settings so caller-provided options are copied safely and forwarded correctly.
  * Preserved custom option values while preventing the original settings object from being modified.

* **Tests**
  * Added regression coverage for connection option forwarding and immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->